### PR TITLE
JSON RPC Port fix for docker.

### DIFF
--- a/Dockerfile-KALI
+++ b/Dockerfile-KALI
@@ -10,5 +10,5 @@ RUN git clone https://github.com/Kalicoin/kalicoin-core.git && cd kalicoin-core/
 RUN mkdir /root/.kalicoin/
 RUN echo "rpcuser=kalicoinrpc" >> /root/.kalicoin/kalicoin.conf
 RUN echo "rpcpassword=kalicoinrpcpassword" >> /root/.kalicoin/kalicoin.conf
-
+EXPOSE 8778
 CMD ["/kalicoin-core/src/kalicoind","-daemon","-listen","-upnp"]


### PR DESCRIPTION
Expose port 8778 for connecting on the Json-RPC.